### PR TITLE
test: add Q CLI and MCP integration testing

### DIFF
--- a/src/config/mcp-config.js
+++ b/src/config/mcp-config.js
@@ -170,9 +170,7 @@ class MCPConfigManager {
    * Check if AWS credentials are available
    */
   hasAWSCredentials() {
-    // Temporarily disabled for testing - return false to disable MCP
-    return false;
-    // return !!(process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY);
+    return !!(process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY);
   }
 
   /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Create a long running integration test workflow that calls the action with a `test_mode: "true"` flag.

In test_mode, the action is called without the need for a Github PR or issue as a trigger, and ingests a prompt passed in directly from the test workflow. The execute.js script is updated to also save the raw Amazon Q output, which includes tool calls.

The integration test uploads the saved raw output file, and then verifies that the output logs a tool call to the CloudWatch Application Signals MCP server.

Example successful test run: https://github.com/ezhang6811/aws-apm-action/actions/runs/18987132452/job/54233151316
Example failed test run (MCP intentionally disabled): https://github.com/ezhang6811/aws-apm-action/actions/runs/18987401897/job/54233964249

Next steps:
* additional tests that input will deterministically generate MCP tool call
* publish CW metric for successful workflow calls
* verify no conflict with regular user invocation of the action

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
